### PR TITLE
Rearrange lead magnets and inline stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -2861,27 +2861,27 @@
 
                 <div class="cta-buttons">
                     <!-- Primary CTA -->
-                    <a href="#services" class="btn btn-primary" style="margin-bottom: 0.8rem;">
+                    <a href="#services" class="btn btn-primary">
                         Get Your CFO Strategy Call
                         <span class="btn-arrow">→</span>
                     </a>
-                    
-                    <!-- Secondary Tools Section -->
-                    <div style="margin-top: 0.5rem;">
-                        <p style="color: #cbd5e1; font-size: 0.9rem; margin-bottom: 0.6rem; font-weight: 500;">
-                            Or explore these free tools first:
-                        </p>
-                        <div class="hero-tools" style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                            <a href="runway-calculator.html" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(218, 165, 32, 0.15); border: 1px solid rgba(218, 165, 32, 0.3); border-radius: 25px; color: var(--gold); text-decoration: none; font-weight: 600; font-size: 0.9rem; transition: all 0.3s ease;">
-                                Runway Calculator
-                            </a>
-                            <a href="https://financier.montpro.xyz/generator.html" target="_blank" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 25px; color: #cbd5e1; text-decoration: none; font-weight: 600; font-size: 0.9rem; transition: all 0.3s ease;">
-                                Statements Generator
-                            </a>
-                            <button onclick="document.getElementById('chatTrigger').click()" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(0, 119, 181, 0.15); border: 1px solid rgba(0, 119, 181, 0.3); border-radius: 25px; color: #5dade2; font-weight: 600; font-size: 0.9rem; cursor: pointer; transition: all 0.3s ease;">
-                                Ask Monty AI
-                            </button>
-                        </div>
+                </div>
+
+                <!-- Lead Magnets Section - Now Below Main CTA -->
+                <div class="hero-lead-magnets" style="margin-top: 2rem;">
+                    <p style="color: #cbd5e1; font-size: 0.9rem; margin-bottom: 1rem; font-weight: 500; text-align: center;">
+                        Or explore these free tools first:
+                    </p>
+                    <div class="hero-tools" style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
+                        <a href="runway-calculator.html" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(218, 165, 32, 0.15); border: 1px solid rgba(218, 165, 32, 0.3); border-radius: 25px; color: var(--gold); text-decoration: none; font-weight: 600; font-size: 0.9rem; transition: all 0.3s ease;">
+                            Runway Calculator
+                        </a>
+                        <a href="https://financier.montpro.xyz/generator.html" target="_blank" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 25px; color: #cbd5e1; text-decoration: none; font-weight: 600; font-size: 0.9rem; transition: all 0.3s ease;">
+                            Statements Generator
+                        </a>
+                        <button onclick="document.getElementById('chatTrigger').click()" class="tool-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1.5rem; background: rgba(0, 119, 181, 0.15); border: 1px solid rgba(0, 119, 181, 0.3); border-radius: 25px; color: #5dade2; font-weight: 600; font-size: 0.9rem; cursor: pointer; transition: all 0.3s ease;">
+                            Ask Monty AI
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Moved lead magnet buttons below the main CTA to improve visual hierarchy and user flow in the hero section.

Previously, the lead magnet buttons were nested within the same `cta-buttons` div as the primary call to action, creating visual clutter. This change separates them into their own section, ensuring the main CTA is prominent while offering secondary options clearly.

---
<a href="https://cursor.com/background-agent?bcId=bc-99c67d92-0123-41ea-9b39-c3e59b038ce3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99c67d92-0123-41ea-9b39-c3e59b038ce3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

